### PR TITLE
Updated requirements.txt in order to prevent an incompatible version of prompt_toolkit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,7 @@ tqdm
 quantstats>=0.0.60
 ipywidgets
 joblib
-
+prompt_toolkit<=3.0.36,>=2.0
 plotly
 bokeh>=3.2
-
 jupyter


### PR DESCRIPTION
This PR addresses a dependency conflict issue that was causing installation errors when setting up the project. 
The questionary package, which is a dependency of our project, requires prompt_toolkit to be in the version range >=2.0,<=3.0.36. However, the installed version of prompt_toolkit was 3.0.43, which is incompatible with the specified requirements of questionary.
By pinning the prompt_toolkit version to <=3.0.36,>=2.0, we are enforcing the installation of a version that is compatible with questionary 2.0.1, thus preventing the aforementioned error.